### PR TITLE
added reset and forgot password routes

### DIFF
--- a/app/(login)/forgot-password/page.tsx
+++ b/app/(login)/forgot-password/page.tsx
@@ -30,14 +30,20 @@ const ForgotPasswordPage = () => {
                     'Content-Type': 'application/json'
                 }
             });
-
+            console.log(response)
             if (response.ok) {
                 setLoadingMessage('Reset Link Sent. Check Your Email.');
                 setDivState('active');
                 router.push(`/reset-password?email=${encodeURIComponent(email)}`);
-            } else {
+            }
+            if (response.status == 405) {
                 setErrState('error');
-                setErrMsg('An error occurred. Please try again.');
+                setErrMsg('Invalid email or email not found');
+                setDivState('active');
+            }
+            else {
+                setErrState('error');
+                setErrMsg('Server error');
                 setDivState('active');
             }
         } catch (error) {

--- a/app/(login)/forgot-password/page.tsx
+++ b/app/(login)/forgot-password/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import Link from "next/link";
+import { Poppins } from "next/font/google";
+import { useState, FormEvent } from "react";
+import { useRouter } from 'next/navigation';
+
+const poppins = Poppins({ subsets: ['latin'], weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"] });
+
+const ForgotPasswordPage = () => {
+    const router = useRouter();
+
+    const [divState, setDivState] = useState('active');
+    const [errState, setErrState] = useState('error-free');
+    const [errMsg, setErrMsg] = useState('');
+    const [loadingMessage, setLoadingMessage] = useState('Sending Reset Link...');
+
+    const onHandleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setDivState("loading");
+
+        const formData = new FormData(event.currentTarget);
+        const email = formData.get('email') as string;
+
+        try {
+            const response = await fetch('http://localhost:8080/user/forgot-password', {
+                method: 'POST',
+                body: JSON.stringify({ email }),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (response.ok) {
+                setLoadingMessage('Reset Link Sent. Check Your Email.');
+                setDivState('active');
+                router.push(`/reset-password?email=${encodeURIComponent(email)}`);
+            } else {
+                setErrState('error');
+                setErrMsg('An error occurred. Please try again.');
+                setDivState('active');
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            setErrState('error');
+            setErrMsg('An error occurred. Please try again.');
+            setDivState('active');
+        }
+    };
+
+    return (
+        <>
+            <div className="absolute z-20 left-0 right-0 mx-auto">
+                <div className="flex flex-col items-center justify-center h-screen">
+                    <div className="w-[350px] md:w-[500px] bg-primary-black-3 mx-auto shadow-md shadow-[#222] p-5">
+                        <h1 className={`text-center text-2xl font-bold ${poppins.className}`}>FORGOT PASSWORD</h1>
+                        <Link href="/login">
+                            <p className="text-center text-sm underline text-primary-orange-2 my-2">Remembered? Sign In Here</p>
+                        </Link>
+                        <form onSubmit={onHandleSubmit}>
+                            <input type='email' name="email" placeholder="Email" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" />
+                            <div className="flex justify-center">
+                                <button type="submit" className="py-2 px-5 mt-5 bg-primary-orange-3 border-2 border-[#222] rounded-md">
+                                    {divState === 'loading' ? (
+                                        <span>{loadingMessage}</span>
+                                    ) : (
+                                        <span>Send OTP</span>
+                                    )}
+                                </button>
+                            </div>
+                        </form>
+
+                        {errState === 'error' && (
+                            <div className="text-red-500 text-sm mt-2">{errMsg}</div>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </>
+    )
+}
+
+export default ForgotPasswordPage;

--- a/app/(login)/reset-password/page.tsx
+++ b/app/(login)/reset-password/page.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState, FormEvent } from 'react';
+import { Poppins } from "next/font/google";
+
+const poppins = Poppins({ subsets: ['latin'], weight: ["100", "200", "300", "400", "500", "600", "700", "800", "900"] });
+
+const ResetPasswordPage = () => {
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const email = searchParams.get('email');
+
+    const [divState, setDivState] = useState('active');
+    const [errState, setErrState] = useState('error-free');
+    const [errMsg, setErrMsg] = useState('');
+    const [loadingMessage, setLoadingMessage] = useState('Resetting Password...');
+
+    const onHandleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        setDivState("loading");
+
+        const formData = new FormData(event.currentTarget);
+        const otp = formData.get('otp') as string;
+        const newPassword = formData.get('newPassword') as string;
+        const confirmNewPassword = formData.get('confirmNewPassword') as string;
+
+        if (newPassword !== confirmNewPassword) {
+            setErrState('error');
+            setErrMsg('Passwords do not match');
+            setDivState('active');
+            return;
+        }
+
+        try {
+            const response = await fetch('http://localhost:8080/user/reset-password', {
+                method: 'POST',
+                body: JSON.stringify({ email, otp, newPassword }),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (response.ok) {
+                setLoadingMessage('Password Reset Successful. Redirecting to Login...');
+                setDivState('active');
+                router.push('/login');
+            } else {
+                setErrState('error');
+                setErrMsg('An error occurred. Please try again.');
+                setDivState('active');
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            setErrState('error');
+            setErrMsg('An error occurred. Please try again.');
+            setDivState('active');
+        }
+    };
+
+    return (
+        <>
+            <div className="absolute z-20 left-0 right-0 mx-auto">
+                <div className="flex flex-col items-center justify-center h-screen">
+                    <div className="w-[350px] md:w-[500px] bg-primary-black-3 mx-auto shadow-md shadow-[#222] p-5">
+                        <h1 className={`text-center text-2xl font-bold ${poppins.className}`}>RESET PASSWORD</h1>
+                        <form onSubmit={onHandleSubmit}>
+                            <input type='text' name="otp" placeholder="OTP" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" />
+                            <input type='password' name="newPassword" placeholder="New Password" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" />
+                            <input type='password' name="confirmNewPassword" placeholder="Confirm New Password" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" />
+                            <div className="flex justify-center">
+                                <button type="submit" className="py-2 px-5 mt-5 bg-primary-orange-3 border-2 border-[#222] rounded-md">
+                                    {divState === 'loading' ? (
+                                        <span>{loadingMessage}</span>
+                                    ) : (
+                                        <span>Reset Password</span>
+                                    )}
+                                </button>
+                            </div>
+                        </form>
+
+                        {errState === 'error' && (
+                            <div className="text-red-500 text-sm mt-2">{errMsg}</div>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </>
+    )
+}
+
+export default ResetPasswordPage;

--- a/app/(login)/reset-password/page.tsx
+++ b/app/(login)/reset-password/page.tsx
@@ -15,6 +15,7 @@ const ResetPasswordPage = () => {
     const [errState, setErrState] = useState('error-free');
     const [errMsg, setErrMsg] = useState('');
     const [loadingMessage, setLoadingMessage] = useState('Resetting Password...');
+    const [otpRegenerateMsg, setOtpRegenerateMsg] = useState('');
 
     const onHandleSubmit = async (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
@@ -45,9 +46,20 @@ const ResetPasswordPage = () => {
                 setLoadingMessage('Password Reset Successful. Redirecting to Login...');
                 setDivState('active');
                 router.push('/login');
-            } else {
+            }
+            else if (response.status == 405) {
                 setErrState('error');
-                setErrMsg('An error occurred. Please try again.');
+                setErrMsg('Invalid OTP, click to regenerate OTP');
+                setDivState('active');
+            }
+            else if (response.status == 401) {
+                setErrState('error');
+                setErrMsg('Cannot reset same password, click to regenerate OTP');
+                setDivState('active');
+            }
+            else {
+                setErrState('error');
+                setErrMsg('Server error');
                 setDivState('active');
             }
         } catch (error) {
@@ -58,6 +70,28 @@ const ResetPasswordPage = () => {
         }
     };
 
+    const onHandleRegenerateOtp = async () => {
+        setOtpRegenerateMsg('Regenerating OTP...');
+        try {
+            const response = await fetch('http://localhost:8080/user/forgot-password', {
+                method: 'POST',
+                body: JSON.stringify({ email }),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            });
+
+            if (response.ok) {
+                setOtpRegenerateMsg('OTP has been regenerated. Please check your email.');
+            } else {
+                setOtpRegenerateMsg('Failed to regenerate OTP. Please try again.');
+            }
+        } catch (error) {
+            console.error('Error:', error);
+            setOtpRegenerateMsg('An error occurred. Please try again.');
+        }
+    };
+
     return (
         <>
             <div className="absolute z-20 left-0 right-0 mx-auto">
@@ -65,9 +99,9 @@ const ResetPasswordPage = () => {
                     <div className="w-[350px] md:w-[500px] bg-primary-black-3 mx-auto shadow-md shadow-[#222] p-5">
                         <h1 className={`text-center text-2xl font-bold ${poppins.className}`}>RESET PASSWORD</h1>
                         <form onSubmit={onHandleSubmit}>
-                            <input type='text' name="otp" placeholder="OTP" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" />
-                            <input type='password' name="newPassword" placeholder="New Password" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" />
-                            <input type='password' name="confirmNewPassword" placeholder="Confirm New Password" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" />
+                            <input type='text' name="otp" placeholder="OTP" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" required />
+                            <input type='password' name="newPassword" placeholder="New Password" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" required />
+                            <input type='password' name="confirmNewPassword" placeholder="Confirm New Password" className="w-[100%] bg-primary-black-2 p-2 mt-5 rounded-md text-white placeholder:text-primary-orange-2 outline-none" required />
                             <div className="flex justify-center">
                                 <button type="submit" className="py-2 px-5 mt-5 bg-primary-orange-3 border-2 border-[#222] rounded-md">
                                     {divState === 'loading' ? (
@@ -82,6 +116,14 @@ const ResetPasswordPage = () => {
                         {errState === 'error' && (
                             <div className="text-red-500 text-sm mt-2">{errMsg}</div>
                         )}
+                        <div className="text-center mt-2">
+                            <button onClick={onHandleRegenerateOtp} className="underline text-primary-orange-2">
+                                Regenerate OTP
+                            </button>
+                            {otpRegenerateMsg && (
+                                <div className="text-primary-orange-2 text-sm mt-2">{otpRegenerateMsg}</div>
+                            )}
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
added error handling in forgot password: if  invalid email or email not found in db, sends a signup message in frontend

email extracted from useParams() in reset-password URL
added a regenerate OTP link below which sends post request to user/forgot-password/:email in backend

added error handling in reset password: 
1)invalid OTP: sends an error of invalid otp and afterUpdate hook in backend deletes it. sends a message to click on regenerate OTP
2)new password and confirm password not matching: sends error message to user
3)new password matches old password in db: sends an error message of matching passwords and afterUpdate hook in backend deletes it. sends a message to click on regenerate OTP

after success redirects to login 